### PR TITLE
Simplify first pass parse

### DIFF
--- a/Null_subjects_corpus_log.txt
+++ b/Null_subjects_corpus_log.txt
@@ -53,7 +53,7 @@ Using lexicon "lexicon.txt".
 
 7.
 
-		Adding inflectional features {'-', 'PHI:DET:DEF', 'LANG:FI', 'PHI:HUM:HUM', 'PHI:PER:3', 'PHI:NUM:SG', 'TAIL:ARG,VAL,CAT:FIN'} to D
+		Adding inflectional features {'-', 'LANG:FI', 'TAIL:ARG,VAL,CAT:FIN', 'PHI:NUM:SG', 'PHI:PER:3', 'PHI:HUM:HUM', 'PHI:DET:DEF'} to D
 		= ['!COMP:*', '!PROBE:CAT:N', '-', '-ARG', '-COMP:T/fin', '-COMP:uR', '-SPEC:N', '-SPEC:Neg/fin', '-SPEC:T/fin', '-SPEC:V', 'CAT:-ARG', 'CAT:-ARG/-ARG/D/D', 'CAT:-ARG/D', 'CAT:D', 'COMP:N', 'LANG:FI', 'LF:D', 'PF:D', 'PHI:DET:DEF', 'PHI:HUM:HUM', 'PHI:NUM:SG', 'PHI:PER:3', 'TAIL:ARG,VAL,CAT:FIN', 'VAL']
 			=D
 
@@ -77,7 +77,7 @@ Using lexicon "lexicon.txt".
 
 10.
 
-		Adding inflectional features {'-', 'PHI:NUM:SG', 'PHI:PER:3', 'LANG:FI'} to T/fin
+		Adding inflectional features {'PHI:PER:3', '-', 'PHI:NUM:SG', 'LANG:FI'} to T/fin
 		= ['!COMP:*', '!PROBE:CAT:V', '!SPEC:*', '-', '-SPEC:FORCE', '-SPEC:N', '-SPEC:T/fin', '-SPEC:V', 'ARG', 'CAT:ARG', 'CAT:ARG/ARG/FIN/T/T/fin/FIN/T/T/fin', 'CAT:ARG/FIN/T/T/fin', 'CAT:FIN', 'CAT:T', 'CAT:T/fin', 'COMP:D', 'COMP:V', 'COMP:v', 'LANG:FI', 'LF:T', 'PF:T/fin', 'PHI:DET:_', 'PHI:NUM:SG', 'PHI:NUM:_', 'PHI:PER:3', 'PHI:PER:_', 'SPEC:*', 'SPEC:TO/inf', 'VAL']
 
 		Consume "T/fin"
@@ -166,16 +166,16 @@ Using lexicon "lexicon.txt".
 				Phrasal movement reconstruction:
 					Dropping A-/A-bar movement.
 				Agreement reconstruction:
-					PRO.T/fin has unvalued phi-features {'PHI:PER:_', 'PHI:NUM:_', 'PHI:DET:_'}
-					phi.T/fin acquired PHI:DET:DEF by phi-Agree from <DP>:2.
+					PRO.T/fin has unvalued phi-features {'PHI:NUM:_', 'PHI:DET:_', 'PHI:PER:_'}
 					phi.T/fin acquired PHI:PER:3 by phi-Agree from <DP>:2.
+					phi.T/fin acquired PHI:DET:DEF by phi-Agree from <DP>:2.
 					phi.T/fin acquired PHI:NUM:SG by phi-Agree from <DP>:2.
 			= [<D Pekka> [T/fin [<D Pekka> [haluaa [A/inf lahtea]]]]]
 		Checking LF-interface conditions.
 			Trying to transfer [<D Pekka>:2 [phi.T/fin [<DP>:2 [PRO.haluaa [A/inf PRO.lahtea]]]]] into Conceptual-Intentional system...
-				PRO.haluaa with {'PHI:PER:_', 'PHI:NUM:_', 'PHI:DET:_'} was associated at LF with:
+				PRO.haluaa with {'PHI:NUM:_', 'PHI:DET:_', 'PHI:PER:_'} was associated at LF with:
 					1. <D Pekka>    (alternatives: 2. T/fin )
-				PRO.lahtea with {'PHI:PER:_', 'PHI:NUM:_', 'PHI:DET:_'} was associated at LF with:
+				PRO.lahtea with {'PHI:NUM:_', 'PHI:DET:_', 'PHI:PER:_'} was associated at LF with:
 					1. <D Pekka>    (alternatives: 2. T/fin )
 				Transfer to C-I successful.
 !--->		Tests passed (with 14/132 operations) <------------------------------------

--- a/Null_subjects_corpus_results.txt
+++ b/Null_subjects_corpus_results.txt
@@ -1,12 +1,12 @@
 Parser-Grammar v. 2.x
-2019-10-07 15:19:58.584780
+2019-10-13 23:50:29.569371
 Test sentences from file "Null_subjects_corpus.txt".
 Logs into file "Null_subjects_corpus_log.txt.
 Lexicon from file "lexicon.txt".
-1.  Pekka haluaa lahtea 
+1.  Pekka haluaa lahtea
 
 [<D Pekka>:1 [phi.T/fin [<DP>:1 [PRO.haluaa [A/inf PRO.lahtea]]]]]
 'D Pekka T __want A/inf leave .'
-{'PRO.haluaa(<D Pekka>)', 'PRO.lahtea(<D Pekka>)'}
+{'PRO.lahtea(<D Pekka>)', 'PRO.haluaa(<D Pekka>)'}
 Score: 0  (Failed: 0, Discourse plausibility: -0)
 

--- a/parse.py
+++ b/parse.py
@@ -180,27 +180,25 @@ for sentence in parse_list[start:]:
 
         # Print the sentence to the log file
         set_logging(True)
-        s = ''
-        for word in sentence:
-            s = s + word + ' '
+        s = ' '.join(sentence)
 
         # If no results were found, the sentence is ungrammatical
         if len(P.result_list) == 0:
-            results_file.write(str(count) + '. * ' + s + '\n\n')
+            results_file.write(f'{count}. * {s}\n\n')
 
         # If results were found, the sentence is grammatical
         else:
             # Marginality estimations are printed here
             if 0 >= P.score >= -6:
-                judgment = grammaticality_judgement[int(round(abs(P.score),0))]
+                judgment = grammaticality_judgement[round(abs(P.score), 0)]
             else:
                 judgment = '##'
-            results_file.write(str(count) + '. ' + judgment + ' ' + s + '\n\n')
+            results_file.write(f'{count}. {judgment} {s}\n\n')
 
             # Print the result into the results file
             parse = P.result_list[0]
             results_file.write(f'{parse}\n')
-            results_file.write('\''+parse.gloss()+'.\'\n')
+            results_file.write(f"'{parse.gloss()}.'\n")
             results_file.write(str(P.semantic_interpretation) + '\n')
             results_file.write('Score: ' + str(P.score) + '  (')
             results_file.write('Failed: ' + str(P.number_of_solutions_tried - 1) + ', ')


### PR DESCRIPTION
Proposing to simplify  _first_pass_parse -method with three changes:

1. Move final evaluation of a solution into its own method.
2. Reduce indentation levels by having outmost for-loop `continue` into next iteration instead of closing the rest of the for-loop step in an `else`-part.
3. Instead of using a lists of all words in a sentence and an index of the current word, use lists of the remaining words, and pop the first word of the list as the current word. Morphological parse is also modified to work without index. There was also a potential error found in existing code where `morphological_parse` always returned the first disambiguated lexical item if the morphology was simple, len(morphemes) == 1. See line 41 in old code: it returns lexical_item sense 0 even when the method was called with some other sense.  